### PR TITLE
Fixes: Fixed syntax errors in calculateSquare function

### DIFF
--- a/buggy_program.cpp
+++ b/buggy_program.cpp
@@ -1,13 +1,13 @@
-
 #include <iostream>
 using namespace std;
 
-int calculateSquare(int n {
+// Bug fixed by tanveer41 - Fixed function definition and cout operator
+int calculateSquare(int n) {
     return n * n; 
 }
 
 int main() {
     int number = 5;
-    cout >> "Square is: " << calculateSquare(number) << endl;
+    cout << "Square is: " << calculateSquare(number) << endl;
     return 0;
 }


### PR DESCRIPTION
Fixed syntax issues:
- Added missing closing parenthesis in function definition
- Replaced wrong cout operator (>> with <<)
Tested the program; it now outputs the correct square.

### 🐛 Bug Summary
1. Function definition was missing a closing parenthesis: `int calculateSquare(int n {`
2. Wrong stream operator used in `cout`: `>>` instead of `<<`

### ✅ Fix Summary
- Corrected syntax and now the output is as expected: `Square is: 25`
